### PR TITLE
Clamp extra Advanced Tablet slots to the supported maximum

### DIFF
--- a/betteradvancedtablet/Patches.cs
+++ b/betteradvancedtablet/Patches.cs
@@ -134,12 +134,15 @@ namespace BetterAdvancedTablet
             //get the first cartridge slot
             var CartridgeSlot = ItemAdvancedTablet.Slots[1];
 
-            //create slots dynamicly
-            for (int countSlots = 0; countSlots < TabletSlots; countSlots++)
+            var slotsToAdd = Math.Min(TabletSlots, 6);
+            if (TabletSlots > 6 && DebugMode)
             {
-                if (countSlots > 5)
-                    return;
+                Debug.Log($"{PluginInfo.PLUGIN_NAME}: Requested {TabletSlots} extra slots but only 6 are supported. Clamping to 6 extra slots.");
+            }
 
+            //create slots dynamically (up to 6 extra slots)
+            for (int countSlots = 0; countSlots < slotsToAdd; countSlots++)
+            {
                 Slot newSlot = new Slot();
                 newSlot.Type = CartridgeSlot.Type;
                 newSlot.IsHiddenInSeat = CartridgeSlot.IsHiddenInSeat;


### PR DESCRIPTION
## Summary
- clamp the number of additional Advanced Tablet cartridge slots to the supported maximum of six
- log a debug message when configuration requests more slots than supported

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5a3370524832198b1c02e34d13e88